### PR TITLE
Remove pytest dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,31 +14,30 @@ source:
 
 build:
   skip: true  # [win]
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python
-    - pip
     - cython
     - numpy
-  run:
+    - pip
     - python
-    - lockfile >=0.10.2
+  run:
     - cachecontrol >=0.11.5
     - decorator >=3.4.2
+    - hdmedians >=0.13
     - ipython >=3.2.0
+    - lockfile >=0.10.2
     - matplotlib-base >=1.4.3
     - natsort >=4.0.3
     - {{ pin_compatible('numpy') }}
     - pandas >=1.0.0
-    - scipy >=1.3.0
-    - hdmedians >=0.13
+    - python
     - scikit-learn >=0.19.1
-    - pytest
+    - scipy >=1.3.0
 
 test:
   imports:
@@ -73,6 +72,10 @@ test:
     - skbio.util.tests
   commands:
     - MPLBACKEND='Agg' python -m skbio.test
+    - pip check
+  requires:
+    - pip
+    - pytest
 
 about:
   home: http://scikit-bio.org


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

as far as I can tell pytest is only needed to run the tests, but not to install scikit-bio.
So I've turned it into a `test:`  dependency rather than a `run:` dependency

I also sorted all dependencies because OCD.

(The PR only contains 1 commit `Remove pytest run dependency …`. Any commits before that will disappear once #28 is merged)